### PR TITLE
Remove the double * formatting in Slack

### DIFF
--- a/src/bcycle-finder.coffee
+++ b/src/bcycle-finder.coffee
@@ -123,7 +123,7 @@ module.exports = (robot) ->
             return formatStationStatus(station)
           )
           .value()
-  
+
         # Send output
         sendMessage output, msg
 
@@ -157,10 +157,10 @@ module.exports = (robot) ->
   robot.respond /bcycle info$/i, (msg) ->
     makeBCycleRequest 'system_information', (err, res, body) ->
       return unless checkForError err, res, body, msg
-    
+
       # Parse system information
       response = JSON.parse(body)
-      
+
       switch robot.adapterName
         when 'slack'
           msg.send {
@@ -260,12 +260,8 @@ module.exports = (robot) ->
   ##
   # Format Station Name
   formatStationName = (station) ->
-        switch robot.adapterName
-          when 'slack'
-            return "**##{formatStationId(station)}** - #{station.name}"
-          else
-            return "##{formatStationId(station)} - #{station.name}"
-    
+    return "##{formatStationId(station)} - #{station.name}"
+
   ##
   # Send message
   sendMessage = (payload, msg) ->

--- a/test/bcycle-finder-slack_test.coffee
+++ b/test/bcycle-finder-slack_test.coffee
@@ -54,7 +54,7 @@ describe 'hubot-bcycle-finder slack', ->
                     "author_link": "https://nashville.bcycle.com/"
                     "author_name": "BCycle"
                     "color": "good"
-                    "fallback": "**#2970** - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave > Active | Bikes: 4 | Docks: 7"
+                    "fallback": "#2970 - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave > Active | Bikes: 4 | Docks: 7"
                     "fields": [
                       {
                         "short": false
@@ -72,7 +72,7 @@ describe 'hubot-bcycle-finder slack', ->
                         "value": 7
                       }
                     ]
-                    "title": "**#2970** - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave"
+                    "title": "#2970 - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave"
                     "ts": 1507606179
                   },
                   {
@@ -80,7 +80,7 @@ describe 'hubot-bcycle-finder slack', ->
                     "author_link": "https://nashville.bcycle.com/"
                     "author_name": "BCycle"
                     "color": "good"
-                    "fallback": "**#2974** - Shelby Bottoms Nature Center: 1900 Davidson St > Active | Bikes: 10 | Docks: 11"
+                    "fallback": "#2974 - Shelby Bottoms Nature Center: 1900 Davidson St > Active | Bikes: 10 | Docks: 11"
                     "fields": [
                       {
                         "short": false
@@ -98,7 +98,7 @@ describe 'hubot-bcycle-finder slack', ->
                         "value": 11
                       }
                     ]
-                    "title": "**#2974** - Shelby Bottoms Nature Center: 1900 Davidson St"
+                    "title": "#2974 - Shelby Bottoms Nature Center: 1900 Davidson St"
                     "ts": 1507606179
                   }
                 ]
@@ -145,42 +145,42 @@ describe 'hubot-bcycle-finder slack', ->
         try
           expect(selfRoom.messages).to.eql [
             ['alice', '@hubot bcycle list']
-            ['hubot', '**#2162** - The District: Commerce & 2nd Ave N']
-            ['hubot', '**#2165** - Fifth Third Plaza: Church St between 4th & 5th Ave N']
-            ['hubot', '**#2166** - Public Square: 3rd Ave N & Union St']
-            ['hubot', '**#2167** - Riverfront Station: Broadway & 1st Ave N']
-            ['hubot', '**#2168** - Cumberland Park: Victory Way at Base of Pedestrian St Bridge']
-            ['hubot', '**#2169** - TPAC: 6th Ave N & Union St']
-            ['hubot', '**#2170** - The Gulch: 11th Ave S & Pine St']
-            ['hubot', '**#2171** - Music Row Roundabout: 16th Ave S']
-            ['hubot', '**#2172** - Centennial Park: 27th Ave N']
-            ['hubot', '**#2173** - Frist Center: 9th Ave S & Demonbreun St']
-            ['hubot', '**#2175** - Hillsboro Village: Wedgewood Ave & 21st Ave S']
-            ['hubot', '**#2176** - Trolley Barns: Peabody St']
-            ['hubot', '**#2177** - 5 Points East Nashville: S 11th St']
-            ['hubot', '**#2179** - Nashville Farmers\' Market: 7th Ave N / Outdoor Food Court']
-            ['hubot', '**#2180** - Germantown: NW 5th Ave & Monroe St']
-            ['hubot', '**#2181** - SoBro: 3rd Ave S & Symphony Pl']
-            ['hubot', '**#2315** - Downtown YMCA: Church St & 9th Ave N']
-            ['hubot', '**#2516** - 12 South Flats: 12th Ave S & Elmwood']
-            ['hubot', '**#2517** - Sevier Park: Kirkwood Ave & 12th Ave S']
-            ['hubot', '**#2684** - Saint Thomas Midtown: Church St. and 20th Ave N']
-            ['hubot', '**#2724** - McCabe Community Center: 103 46th Ave N']
-            ['hubot', '**#2970** - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave']
-            ['hubot', '**#2971** - Morgan Park: Magdeburg Greenway & 4th Ave N']
-            ['hubot', '**#2973** - Belmont Boulevard: 2101 Belmont Blvd']
-            ['hubot', '**#2974** - Shelby Bottoms Nature Center: 1900 Davidson St']
-            ['hubot', '**#2975** - First Tennessee Park: Junior Gilliam Way & 5th Ave N']
-            ['hubot', '**#3260** - Walk of Fame Park: 5th Ave S  & Demonbreun St.']
-            ['hubot', '**#3271** - J. Percy Priest Dam Trailhead: Stones River Greenway off Bell Rd']
-            ['hubot', '**#3315** - Two Rivers Skatepark: Two Rivers Greenway']
-            ['hubot', '**#3349** - Hadley Park Community Center: 1037 28th Ave North']
-            ['hubot', '**#3456** - 40th Ave. N and Charlotte Ave. ']
-            ['hubot', '**#3467** - Charlotte Ave and 46th Ave N ']
-            ['hubot', '**#3568** - 200 21st Ave South']
-            ['hubot', '**#3569** - Parthenon ']
-            ['hubot', '**#3597** - Ted Rhodes Golf Course: 1901 Ed Temple Blvd']
-            ['hubot', '**#3613** - 715 Porter Road']
+            ['hubot', '#2162 - The District: Commerce & 2nd Ave N']
+            ['hubot', '#2165 - Fifth Third Plaza: Church St between 4th & 5th Ave N']
+            ['hubot', '#2166 - Public Square: 3rd Ave N & Union St']
+            ['hubot', '#2167 - Riverfront Station: Broadway & 1st Ave N']
+            ['hubot', '#2168 - Cumberland Park: Victory Way at Base of Pedestrian St Bridge']
+            ['hubot', '#2169 - TPAC: 6th Ave N & Union St']
+            ['hubot', '#2170 - The Gulch: 11th Ave S & Pine St']
+            ['hubot', '#2171 - Music Row Roundabout: 16th Ave S']
+            ['hubot', '#2172 - Centennial Park: 27th Ave N']
+            ['hubot', '#2173 - Frist Center: 9th Ave S & Demonbreun St']
+            ['hubot', '#2175 - Hillsboro Village: Wedgewood Ave & 21st Ave S']
+            ['hubot', '#2176 - Trolley Barns: Peabody St']
+            ['hubot', '#2177 - 5 Points East Nashville: S 11th St']
+            ['hubot', '#2179 - Nashville Farmers\' Market: 7th Ave N / Outdoor Food Court']
+            ['hubot', '#2180 - Germantown: NW 5th Ave & Monroe St']
+            ['hubot', '#2181 - SoBro: 3rd Ave S & Symphony Pl']
+            ['hubot', '#2315 - Downtown YMCA: Church St & 9th Ave N']
+            ['hubot', '#2516 - 12 South Flats: 12th Ave S & Elmwood']
+            ['hubot', '#2517 - Sevier Park: Kirkwood Ave & 12th Ave S']
+            ['hubot', '#2684 - Saint Thomas Midtown: Church St. and 20th Ave N']
+            ['hubot', '#2724 - McCabe Community Center: 103 46th Ave N']
+            ['hubot', '#2970 - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave']
+            ['hubot', '#2971 - Morgan Park: Magdeburg Greenway & 4th Ave N']
+            ['hubot', '#2973 - Belmont Boulevard: 2101 Belmont Blvd']
+            ['hubot', '#2974 - Shelby Bottoms Nature Center: 1900 Davidson St']
+            ['hubot', '#2975 - First Tennessee Park: Junior Gilliam Way & 5th Ave N']
+            ['hubot', '#3260 - Walk of Fame Park: 5th Ave S  & Demonbreun St.']
+            ['hubot', '#3271 - J. Percy Priest Dam Trailhead: Stones River Greenway off Bell Rd']
+            ['hubot', '#3315 - Two Rivers Skatepark: Two Rivers Greenway']
+            ['hubot', '#3349 - Hadley Park Community Center: 1037 28th Ave North']
+            ['hubot', '#3456 - 40th Ave. N and Charlotte Ave. ']
+            ['hubot', '#3467 - Charlotte Ave and 46th Ave N ']
+            ['hubot', '#3568 - 200 21st Ave South']
+            ['hubot', '#3569 - Parthenon ']
+            ['hubot', '#3597 - Ted Rhodes Golf Course: 1901 Ed Temple Blvd']
+            ['hubot', '#3613 - 715 Porter Road']
           ]
           done()
         catch err
@@ -205,7 +205,7 @@ describe 'hubot-bcycle-finder slack', ->
                     "author_link": "https://nashville.bcycle.com/"
                     "author_name": "BCycle"
                     "color": "good"
-                    "fallback": "**#2970** - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave > Active | Bikes: 4 | Docks: 7"
+                    "fallback": "#2970 - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave > Active | Bikes: 4 | Docks: 7"
                     "fields": [
                       {
                         "short": false
@@ -223,7 +223,7 @@ describe 'hubot-bcycle-finder slack', ->
                         "value": 7
                       }
                     ]
-                    "title": "**#2970** - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave"
+                    "title": "#2970 - Hill Center Trailhead: Richland Creek Greenway & N Kenner Ave"
                     "ts": 1507606179
                   }
                 ]
@@ -244,7 +244,7 @@ describe 'hubot-bcycle-finder slack', ->
         try
           expect(selfRoom.messages).to.eql [
             ['alice', '@hubot bcycle search broadway']
-            ['hubot', '**#2167** - Riverfront Station: Broadway & 1st Ave N']
+            ['hubot', '#2167 - Riverfront Station: Broadway & 1st Ave N']
           ]
           done()
         catch err


### PR DESCRIPTION
These are already shown as bold in attachment headings.